### PR TITLE
add simple integration test, migrate to stdlib HttpStatus

### DIFF
--- a/common/http.py
+++ b/common/http.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+# python <= 3.10 no HTTPMethod in stdlib
+
+
+class HTTPMethod(str, Enum):
+    DELETE = "DELETE"
+    GET = "GET"
+    POST = "POST"

--- a/common/status.py
+++ b/common/status.py
@@ -1,5 +1,0 @@
-from enum import Enum
-
-
-class StatusCode(int, Enum):
-    ACCEPTED = 202

--- a/server/api.py
+++ b/server/api.py
@@ -8,7 +8,7 @@ from common.models import (
     CreateIncidentDto,
     RemoveIncidentDto)
 from common.logger import get_logger
-from common.status import StatusCode
+from http import HTTPStatus
 
 
 log = get_logger(__file__, level="DEBUG", disable_ansi=False)
@@ -28,16 +28,18 @@ def build_app(queue: mp.Queue,
 
     app = FastAPI(title="tcon API", version="0.0.2")
 
-    @app.get("/health")
+    @app.get("/health", status_code=HTTPStatus.OK)
     def health():
         log.debug("Health check request")
-        return {"status": "it's alive!"}
+        return {"status": "I'm chilling."}
 
-    @app.post("/incident", status_code=StatusCode.ACCEPTED)
+    @app.post("/incident", status_code=HTTPStatus.ACCEPTED)
     def create_incident(incident: CreateIncidentDto):
         return _accept(CommandType.INCIDENT_CREATE, incident.model_dump())
 
-    @app.delete("/incident", status_code=StatusCode.ACCEPTED)
+    # RFC 9110 - `content received in a DELETE request has no generally defined semantics`
+    # we could put the information in request parameters, but this is more comfortable
+    @app.delete("/incident", status_code=HTTPStatus.ACCEPTED)
     def remove_incident(incident: RemoveIncidentDto):
         return _accept(CommandType.INCIDENT_REMOVE, incident.model_dump())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,19 +17,6 @@ def fake_aapi(monkeypatch):
     sys.modules["AAPI"] = aapi
 
 
-def _dummy_run_api(*_args, **_kwargs):
-    # Block until SIGTERM, then exit.  Keeps the child alive for assertions.
-    signal.signal(signal.SIGTERM, lambda *_: exit(0))
-    while True:
-        time.sleep(0.1)
-
-
-@pytest.fixture(autouse=True)
-def patch_api(monkeypatch):
-    monkeypatch.setattr(server.api, "run_api_process", _dummy_run_api)
-    yield
-
-
 @pytest.fixture
 # type: ignore[override] – we shadow the built‑in on purpose
 def tmp_path() -> Path:

--- a/tests/test_ipc_integration.py
+++ b/tests/test_ipc_integration.py
@@ -1,0 +1,98 @@
+"""
+Requires the real server.api implementation and the DTO pydantic models.
+Mark with `pytest -m integration` to run only these slower, networked tests.
+"""
+from __future__ import annotations
+
+import contextlib
+import socket
+import time
+
+import httpx
+import pytest
+from server.ipc import ServerProcess
+from common.models import (
+    CommandType,
+    CreateIncidentDto,
+    RemoveIncidentDto)
+from common.http import HTTPMethod
+from http import HTTPStatus
+
+
+# helpers
+def _free_port() -> int:
+    """Return a random free TCP port on localhost."""
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_until_ready(client: httpx.Client,
+                      timeout: float = 10.0,
+                      step: float = 0.1) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if client.get("/health").status_code == HTTPStatus.OK:
+                return True
+        except httpx.TransportError:
+            pass
+        time.sleep(step)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Test                                                                        #
+# --------------------------------------------------------------------------- #
+@pytest.mark.integration
+def test_full_stack_with_dtos():
+    port = _free_port()
+    srv = ServerProcess(host="127.0.0.1", port=port)
+    srv.start()
+
+    try:
+        client = httpx.Client(
+            base_url=f"http://127.0.0.1:{port}",
+            timeout=5)
+
+        # 1)  /health --------------------------------------------------------
+        assert _wait_until_ready(client)
+
+        # 2)  POST /incident  -----------------------------------------------
+        create_dto = CreateIncidentDto(
+            section_id=1,
+            lane=1,
+            position=0.0,
+            length=10.0,
+            ini_time=0.0,
+            duration=600.0,
+        )
+        r = client.post("/incident", json=create_dto.model_dump())
+        assert r.status_code == HTTPStatus.ACCEPTED
+
+        assert srv.notify.wait(timeout=1.0)
+        cmd = next(srv.try_recv_all())
+        assert cmd["type"] == CommandType.INCIDENT_CREATE
+        assert cmd["payload"]["section_id"] == 1
+        srv.notify.clear()
+        assert not srv.notify.is_set()
+
+        # 3)  DELETE /incident  ---------------------------------------------
+        remove_dto = RemoveIncidentDto(
+            section_id=1,
+            lane=1,
+            position=0.0,
+        )
+        r = client.request(HTTPMethod.DELETE,
+                           "/incident",
+                           json=remove_dto.model_dump())
+        assert r.status_code == HTTPStatus.ACCEPTED
+
+        assert srv.notify.wait(timeout=1.0)
+        cmd2 = next(srv.try_recv_all())
+        assert cmd2["type"] == CommandType.INCIDENT_REMOVE
+        assert cmd2["payload"]["lane"] == 1
+        srv.notify.clear()
+    finally:
+        client.close()
+        srv.stop()

--- a/tests/test_ipc_unit.py
+++ b/tests/test_ipc_unit.py
@@ -4,8 +4,6 @@ Unit‑tests for the queue‑based IPC without starting Uvicorn.
 import signal
 import time
 import multiprocessing as mp
-from pathlib import Path
-import uuid
 
 import pytest
 
@@ -24,7 +22,6 @@ def _dummy_run_api(queue: mp.Queue, event: mp.Event, *_):
 @pytest.fixture(autouse=True)
 def _patch_api(monkeypatch):
     monkeypatch.setattr(server.api, "run_api_process", _dummy_run_api)
-    yield    # fixture auto‑unpatches
 
 
 # Tests


### PR DESCRIPTION
This pull request introduces several updates to refactor the codebase, enhance test coverage, and improve HTTP handling. The key changes include replacing a custom `StatusCode` enum with the standard library's `HTTPStatus`, adding a new `HTTPMethod` enum for HTTP verbs, and implementing a full-stack integration test for the API.

### HTTP Handling Improvements:
* Introduced a new `HTTPMethod` enum in `common/http.py` to standardize HTTP method strings (`GET`, `POST`, `DELETE`).
* Replaced the custom `StatusCode` enum with the standard `HTTPStatus` class in `server/api.py`, ensuring consistency with Python's standard library. [[1]](diffhunk://#diff-6364e70c38ed1e30bd82408b75533ed116512386a1172cdd3054985de2c0dffaL1-L5) [[2]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adL11-R11)
* Updated API endpoint decorators to use `HTTPStatus` for status codes and modified the `/health` endpoint response message.

### Test Enhancements:
* Removed the `_dummy_run_api` function and its associated patching in `tests/conftest.py` to clean up unused test code.
* Added a comprehensive full-stack integration test in `tests/test_ipc_integration.py` to validate the API's behavior with real DTOs and network communication. This includes testing the `/health`, `POST /incident`, and `DELETE /incident` endpoints.

### Minor Cleanup:
* Removed unused imports (`Path`, `uuid`) from `tests/test_ipc_unit.py` and adjusted the `_patch_api` fixture. [[1]](diffhunk://#diff-cfd69d78e9a36ccfcb9048affdaaa925dc6fcb9e1bea63acba121be3102b1f62L7-L8) [[2]](diffhunk://#diff-cfd69d78e9a36ccfcb9048affdaaa925dc6fcb9e1bea63acba121be3102b1f62L27)