### PR TITLE
dispatch

### DIFF
--- a/common/result.py
+++ b/common/result.py
@@ -1,0 +1,34 @@
+from typing import TypeVar, Generic, Optional
+from common.status import AimsunStatus
+
+T = TypeVar("T")
+
+
+class Result(Generic[T]):
+    def __init__(
+        self,
+        status: AimsunStatus,
+        value: Optional[T] = None,
+        raw_code: Optional[int] = None,
+        message: Optional[str] = None,
+    ):
+        self.status = status
+        self.value = value
+        self.raw_code = raw_code
+        self.message = message
+
+    def is_ok(self) -> bool:
+        return self.status == AimsunStatus.OK
+
+    def unwrap(self) -> T:
+        if not self.is_ok():
+            raise RuntimeError("error unwrapped")
+        return self.value
+
+    def __repr__(self) -> str:
+        return f"Result(status={self.status}, value={self.value}, code={self.raw_code}, msg={self.message})"
+
+
+def from_aimsun_code(code: int, *, value: Optional[T] = None, msg: Optional[str] = None) -> Result[T]:
+    status = AimsunStatus.from_code(code)
+    return Result(status=status, value=value if status == AimsunStatus.OK else None, raw_code=code, message=msg)

--- a/common/result.py
+++ b/common/result.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TypeVar, Generic, Optional
 from common.status import AimsunStatus
 
@@ -28,7 +29,16 @@ class Result(Generic[T]):
     def __repr__(self) -> str:
         return f"Result(status={self.status}, value={self.value}, code={self.raw_code}, msg={self.message})"
 
-
-def from_aimsun_code(code: int, *, value: Optional[T] = None, msg: Optional[str] = None) -> Result[T]:
-    status = AimsunStatus.from_code(code)
-    return Result(status=status, value=value if status == AimsunStatus.OK else None, raw_code=code, message=msg)
+    # TODO: hopefully the API is consistent with err values as < 0...
+    @classmethod
+    def from_aimsun(cls,
+                    result: int, *,
+                    msg_ok: str = None,
+                    msg_fail: str = None) -> Result[int]:
+        success = result >= 0
+        status = AimsunStatus.OK if success else AimsunStatus.from_code(result)
+        message = (msg_ok if success else msg_fail)
+        return cls(status=status,
+                   raw_code=result,
+                   value=result if success else None,
+                   message=message)

--- a/common/status.py
+++ b/common/status.py
@@ -1,0 +1,35 @@
+from enum import IntEnum
+
+# extracted from aimsun C++ code
+
+
+class AimsunStatus(IntEnum):
+    OK = 0
+
+    # Incident-specific errors
+    INCIDENT_WRONG_INITIME = -8001
+    INCIDENT_WRONG_POSITION = -8002
+    INCIDENT_UNKNOWN_LANE = -8003
+    INCIDENT_UNKNOWN_SECTION = -8004
+    INCIDENT_NOT_PRESENT = -8005
+    INCIDENT_WRONG_LENGTH = -8006
+    INCIDENT_WRONG_DURATION = -8007
+
+    # Network info errors
+    INF_NET_GET_MEM = -5001
+    INF_UNKNOWN_ID = -5002
+    INF_UNKNOWN_TURNING = -5003
+    INF_UNKNOWN_FROM_SECTION = -5004
+    INF_UNKNOWN_TO_SECTION = -5005
+    INF_NO_PATH = -5006
+
+    # Fallbacks
+    UNKNOWN_ERROR = -9999
+    API_FAILURE = -1
+
+    @classmethod
+    def from_code(cls, code: int) -> "AimsunStatus":
+        try:
+            return AimsunStatus(code)
+        except ValueError:
+            return cls.UNKNOWN_ERROR if code < 0 else cls.OK

--- a/server/api.py
+++ b/server/api.py
@@ -16,17 +16,15 @@ from http import HTTPStatus
 log = get_logger(__file__, level="DEBUG", disable_ansi=False)
 
 
-def build_app(queue: mp.Queue,
-              notify_event: mp.Event):
+def build_app(queue: mp.Queue):
     app = FastAPI(title="tcon API", version="0.0.2")
-    register_utility(app, queue, notify_event)
-    register_incidents(app, queue, notify_event)
+    register_utility(app, queue)
+    register_incidents(app, queue)
 
     return app
 
 
 def _accept(queue: mp.Queue,
-            notify_event: mp.Event,
             command_type: CommandType,
             payload: dict[str, any] = None) -> dict[str, any]:
     if isinstance(payload, BaseModel):
@@ -34,42 +32,39 @@ def _accept(queue: mp.Queue,
     command = Command(type=command_type, payload=payload).model_dump()
 
     queue.put(command)
-    notify_event.set()
 
     log.debug("Accepted command: \n%s", json.dumps(command, indent=2))
     return {"accepted": True}
 
 
 def register_incidents(app: FastAPI,
-                       queue: mp.Queue,
-                       notify_event: mp.Event):
+                       queue: mp.Queue):
 
     @app.post("/incident", status_code=HTTPStatus.ACCEPTED)
     def incident_create(incident: IncidentCreateDto):
         # TODO: support the aimsun visibility for 7.0 models or not?
-        return _accept(queue, notify_event, CommandType.INCIDENT_CREATE, incident.model_dump())
+        return _accept(queue,  CommandType.INCIDENT_CREATE, incident.model_dump())
 
     # FIXME: this doesn't work, incident not present... WTF
     @app.delete("/incident", status_code=HTTPStatus.ACCEPTED)
     def incident_remove(incident: IncidentRemoveDto):
-        _accept(queue, notify_event, CommandType.INCIDENT_REMOVE, incident.model_dump())
+        _accept(queue,  CommandType.INCIDENT_REMOVE, incident.model_dump())
         return {"msg": "Thanks for the command, sadly this one isn't implemented in Aimsun API correctly..."}
 
     @app.delete("/incidents/section/{section_id}")
     def incidents_clear_section(section_id=Path(...)):
         return _accept(queue,
-                       notify_event,
+
                        CommandType.INCIDENTS_CLEAR_SECTION,
                        IncidentsClearSectionDto(section_id=section_id))
 
     @app.delete("/incidents/reset")
     def incidents_reset_all():
-        return _accept(queue, notify_event, CommandType.INCIDENTS_RESET)
+        return _accept(queue,  CommandType.INCIDENTS_RESET)
 
 
 def register_utility(app: FastAPI,
-                     queue: mp.Queue,
-                     notify_event: mp.Event):
+                     queue: mp.Queue):
     @app.get("/health", status_code=HTTPStatus.OK)
     def _health():
         return {"status": "chilling"}
@@ -77,12 +72,11 @@ def register_utility(app: FastAPI,
 
 def run_api_process(
         queue: mp.Queue,
-        notify_event: mp.Event,
         host: str = "127.0.0.1",
         port: int = 6969) -> None:
     import uvicorn
     log.info("API listening on http://%s:%d", host, port)
-    app = build_app(queue, notify_event)
+    app = build_app(queue)
     uvicorn.run(app,
                 host=host,
                 port=port,

--- a/server/api.py
+++ b/server/api.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 import multiprocessing as mp
-from fastapi import FastAPI
+from fastapi import FastAPI, Header, Path
 import json
 from common.models import (
     Command,
     CommandType,
-    CreateIncidentDto,
-    RemoveIncidentDto)
+    IncidentCreateDto,
+    IncidentRemoveDto,
+    IncidentsClearSectionDto)
+from pydantic import BaseModel
 from common.logger import get_logger
 from http import HTTPStatus
 
@@ -16,34 +18,49 @@ log = get_logger(__file__, level="DEBUG", disable_ansi=False)
 
 def build_app(queue: mp.Queue,
               notify_event: mp.Event):
-    def _accept(command_type: CommandType,
-                payload: dict[str, any]) -> dict[str, any]:
-        command = Command(type=command_type, payload=payload).model_dump()
-
-        queue.put(command)
-        notify_event.set()
-
-        log.debug("Accepted command: \n%s", json.dumps(command, indent=2))
-        return {"accepted": True}
-
     app = FastAPI(title="tcon API", version="0.0.2")
-
-    @app.get("/health", status_code=HTTPStatus.OK)
-    def health():
-        log.debug("Health check request")
-        return {"status": "I'm chilling."}
-
-    @app.post("/incident", status_code=HTTPStatus.ACCEPTED)
-    def create_incident(incident: CreateIncidentDto):
-        return _accept(CommandType.INCIDENT_CREATE, incident.model_dump())
-
-    # RFC 9110 - `content received in a DELETE request has no generally defined semantics`
-    # we could put the information in request parameters, but this is more comfortable
-    @app.delete("/incident", status_code=HTTPStatus.ACCEPTED)
-    def remove_incident(incident: RemoveIncidentDto):
-        return _accept(CommandType.INCIDENT_REMOVE, incident.model_dump())
+    register_incidents(app, queue, notify_event)
 
     return app
+
+
+def _accept(queue: mp.Queue,
+            notify_event: mp.Event,
+            command_type: CommandType,
+            payload: dict[str, any] = None) -> dict[str, any]:
+    if isinstance(payload, BaseModel):
+        payload = payload.model_dump()
+    command = Command(type=command_type, payload=payload).model_dump()
+
+    queue.put(command)
+    notify_event.set()
+
+    log.debug("Accepted command: \n%s", json.dumps(command, indent=2))
+    return {"accepted": True}
+
+
+def register_incidents(app: FastAPI,
+                       queue: mp.Queue,
+                       notify_event: mp.Event):
+
+    @app.post("/incident", status_code=HTTPStatus.ACCEPTED)
+    def incident_create(incident: IncidentCreateDto):
+        return _accept(queue, notify_event, CommandType.INCIDENT_CREATE, incident.model_dump())
+
+    @app.delete("/incident", status_code=HTTPStatus.ACCEPTED)
+    def incident_remove(incident: IncidentRemoveDto):
+        return _accept(queue, notify_event, CommandType.INCIDENT_REMOVE, incident.model_dump())
+
+    @app.delete("/incidents/section/{section_id}")
+    def incidents_clear_section(section_id=Path(...)):
+        return _accept(queue,
+                       notify_event,
+                       CommandType.INCIDENTS_CLEAR_SECTION,
+                       IncidentsClearSectionDto(section_id=section_id))
+
+    @app.delete("/incidents/reset")
+    def incidents_reset_all():
+        return _accept(queue, notify_event, CommandType.INCIDENTS_RESET)
 
 
 def run_api_process(

--- a/server/api.py
+++ b/server/api.py
@@ -45,11 +45,14 @@ def register_incidents(app: FastAPI,
 
     @app.post("/incident", status_code=HTTPStatus.ACCEPTED)
     def incident_create(incident: IncidentCreateDto):
+        # TODO: support the aimsun visibility for 7.0 models or not?
         return _accept(queue, notify_event, CommandType.INCIDENT_CREATE, incident.model_dump())
 
+    # FIXME: this doesn't work, incident not present... WTF
     @app.delete("/incident", status_code=HTTPStatus.ACCEPTED)
     def incident_remove(incident: IncidentRemoveDto):
-        return _accept(queue, notify_event, CommandType.INCIDENT_REMOVE, incident.model_dump())
+        _accept(queue, notify_event, CommandType.INCIDENT_REMOVE, incident.model_dump())
+        return {"msg": "Thanks for the command, sadly this one isn't implemented in Aimsun API correctly..."}
 
     @app.delete("/incidents/section/{section_id}")
     def incidents_clear_section(section_id=Path(...)):

--- a/server/api.py
+++ b/server/api.py
@@ -19,6 +19,7 @@ log = get_logger(__file__, level="DEBUG", disable_ansi=False)
 def build_app(queue: mp.Queue,
               notify_event: mp.Event):
     app = FastAPI(title="tcon API", version="0.0.2")
+    register_utility(app, queue, notify_event)
     register_incidents(app, queue, notify_event)
 
     return app
@@ -64,6 +65,14 @@ def register_incidents(app: FastAPI,
     @app.delete("/incidents/reset")
     def incidents_reset_all():
         return _accept(queue, notify_event, CommandType.INCIDENTS_RESET)
+
+
+def register_utility(app: FastAPI,
+                     queue: mp.Queue,
+                     notify_event: mp.Event):
+    @app.get("/health", status_code=HTTPStatus.OK)
+    def _health():
+        return {"status": "chilling"}
 
 
 def run_api_process(

--- a/tests/test_ipc_integration.py
+++ b/tests/test_ipc_integration.py
@@ -13,8 +13,9 @@ import pytest
 from server.ipc import ServerProcess
 from common.models import (
     CommandType,
-    CreateIncidentDto,
-    RemoveIncidentDto)
+    IncidentCreateDto,
+    IncidentRemoveDto,
+    IncidentsClearSectionDto)
 from common.http import HTTPMethod
 from http import HTTPStatus
 
@@ -59,7 +60,7 @@ def test_full_stack_with_dtos():
         assert _wait_until_ready(client)
 
         # 2)  POST /incident  -----------------------------------------------
-        create_dto = CreateIncidentDto(
+        create_dto = IncidentCreateDto(
             section_id=1,
             lane=1,
             position=0.0,
@@ -74,11 +75,9 @@ def test_full_stack_with_dtos():
         cmd = next(srv.try_recv_all())
         assert cmd["type"] == CommandType.INCIDENT_CREATE
         assert cmd["payload"]["section_id"] == 1
-        srv.notify.clear()
-        assert not srv.notify.is_set()
 
         # 3)  DELETE /incident  ---------------------------------------------
-        remove_dto = RemoveIncidentDto(
+        remove_dto = IncidentRemoveDto(
             section_id=1,
             lane=1,
             position=0.0,
@@ -92,7 +91,6 @@ def test_full_stack_with_dtos():
         cmd2 = next(srv.try_recv_all())
         assert cmd2["type"] == CommandType.INCIDENT_REMOVE
         assert cmd2["payload"]["lane"] == 1
-        srv.notify.clear()
     finally:
         client.close()
         srv.stop()

--- a/tests/test_ipc_integration.py
+++ b/tests/test_ipc_integration.py
@@ -71,7 +71,6 @@ def test_full_stack_with_dtos():
         r = client.post("/incident", json=create_dto.model_dump())
         assert r.status_code == HTTPStatus.ACCEPTED
 
-        assert srv.notify.wait(timeout=1.0)
         cmd = next(srv.try_recv_all())
         assert cmd["type"] == CommandType.INCIDENT_CREATE
         assert cmd["payload"]["section_id"] == 1
@@ -87,7 +86,6 @@ def test_full_stack_with_dtos():
                            json=remove_dto.model_dump())
         assert r.status_code == HTTPStatus.ACCEPTED
 
-        assert srv.notify.wait(timeout=1.0)
         cmd2 = next(srv.try_recv_all())
         assert cmd2["type"] == CommandType.INCIDENT_REMOVE
         assert cmd2["payload"]["lane"] == 1

--- a/tests/test_ipc_unit.py
+++ b/tests/test_ipc_unit.py
@@ -74,3 +74,10 @@ def test_restart_after_hard_kill():
         assert srv._proc.is_alive()
     finally:
         srv.stop()
+
+
+def test_recv_when_empty_clears_flag():
+    with ServerProcess() as srv:
+        srv.notify.set()
+        list(srv.try_recv_all())
+        assert not srv.notify.is_set()

--- a/tests/test_ipc_unit.py
+++ b/tests/test_ipc_unit.py
@@ -33,7 +33,6 @@ def test_start_stop_cycle():
         assert srv._proc and srv._proc.is_alive()
 
         srv.queue.put({"hello": 1})
-        srv.notify.set()
 
         # Wait for the feeder thread to actually put it there
         # in the simulation we don't block on purpose
@@ -46,13 +45,11 @@ def test_start_stop_cycle():
             time.sleep(0.005)
 
         assert msgs == [{"hello": 1}]
-        assert not srv.notify.is_set()
     finally:
         srv.stop()
 
     assert srv._proc is None
     assert srv.queue is None
-    assert srv.notify is None
 
 
 def test_restart_after_hard_kill():
@@ -74,10 +71,3 @@ def test_restart_after_hard_kill():
         assert srv._proc.is_alive()
     finally:
         srv.stop()
-
-
-def test_recv_when_empty_clears_flag():
-    with ServerProcess() as srv:
-        srv.notify.set()
-        list(srv.try_recv_all())
-        assert not srv.notify.is_set()


### PR DESCRIPTION
### Command Handling Enhancements:
* Introduced a command handler registry (`_HANDLERS`) in `aimsun_entrypoint.py`, enabling dynamic registration and execution of handlers for various command types. Added handlers for `INCIDENT_CREATE`, `INCIDENT_REMOVE`, `INCIDENTS_CLEAR_SECTION`, and `INCIDENTS_RESET` commands.
* Implemented a `register_handler` decorator for associating handlers with specific command types, improving extensibility.

### API Improvements:
* Updated FastAPI endpoints in `server/api.py` to support new commands (`/incidents/section/{section_id}` and `/incidents/reset`) and refactored existing endpoints for incident creation and removal.
* Refactored `_accept` to handle both dictionary and `BaseModel` payloads, ensuring compatibility with new DTOs.

### Data Model Enhancements:
* Added new DTOs (`IncidentCreateDto`, `IncidentRemoveDto`, `IncidentsClearSectionDto`) and a `register_command` decorator in `common/models.py` to map command types to their respective payload models. [[1]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208L7-R42) [[2]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208L58-R83)
* Introduced a `Result` class in `common/result.py` for consistent handling of operation outcomes, with support for Aimsun-specific statuses.

### IPC Simplification:
* Removed the `notify` event from `ServerProcess` in `server/ipc.py`, simplifying the IPC mechanism. Commands are now processed directly from the queue without additional synchronization. [[1]](diffhunk://#diff-a3f6d342575711531bc0700fb76bb3776281b32c5f3a1bdd3a0d836e7ccded43L26) [[2]](diffhunk://#diff-a3f6d342575711531bc0700fb76bb3776281b32c5f3a1bdd3a0d836e7ccded43L36-R35) [[3]](diffhunk://#diff-a3f6d342575711531bc0700fb76bb3776281b32c5f3a1bdd3a0d836e7ccded43L55-L64)

### Testing Updates:
* Updated `tests/test_ipc_integration.py` to use the new DTOs and removed references to the deprecated `notify` event. [[1]](diffhunk://#diff-cd5a89a99a2982af6c50396bfd1d173e26f428e8602234d70ea69b2ec3b8a2cdL16-R18) [[2]](diffhunk://#diff-cd5a89a99a2982af6c50396bfd1d173e26f428e8602234d70ea69b2ec3b8a2cdL62-R63) [[3]](diffhunk://#diff-cd5a89a99a2982af6c50396bfd1d173e26f428e8602234d70ea69b2ec3b8a2cdL73-R79) [[4]](diffhunk://#diff-cd5a89a99a2982af6c50396bfd1d173e26f428e8602234d70ea69b2ec3b8a2cdL91-L95)