### PR TITLE
feat: support policy interaction via API

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -28,6 +28,8 @@ class CommandType(str, Enum):
     MEASURE_CREATE = "measure_create"
     MEASURE_REMOVE = "measure_remove"
     MEASURES_CLEAR = "measures_clear"
+    POLICY_ACTIVATE = "policy_activate"
+    POLICY_DEACTIVATE = "policy_deactivate"
 
 
 class MeasureType(str, Enum):
@@ -88,9 +90,8 @@ class IncidentsClearSectionDto(BaseModel):
                             description="Identifier of the section to clear of incidents")
 # < Incidents -----------------------------------------------------------------
 
+
 # > Measures --------------------------------------------------------------------
-
-
 class _MeasureBase(BaseModel):
     id_action: int | None = Field(default=None,
                                   description="Preallocate the ID only if you know what you're doing, otherwise omit this field")
@@ -238,6 +239,14 @@ class MeasureRemoveDto(BaseModel):
 # < Measures --------------------------------------------------------------------
 
 
+# > Policies --------------------------------------------------------------------
+class PolicyTargetDto(BaseModel):
+    policy_id: int = Field(...,
+                           description="ID of the policy to affect",
+                           gt=0)
+# < Policies --------------------------------------------------------------------
+
+
 # > Command Wrappers ------------------------------------------------------------
 class CommandBase(BaseModel):
     IMMEDIATE: ClassVar[float] = -1
@@ -297,6 +306,16 @@ class MeasuresClearCmd(CommandBase):
     payload: None = Field(default=None)
 
 
+class PolicyActivateCmd(CommandBase):
+    command: Literal[CommandType.POLICY_ACTIVATE] = CommandType.POLICY_ACTIVATE
+    payload: PolicyTargetDto
+
+
+class PolicyDeactivateCmd(CommandBase):
+    command: Literal[CommandType.POLICY_DEACTIVATE] = CommandType.POLICY_DEACTIVATE
+    payload: PolicyTargetDto
+
+
 Command = Annotated[
     Union[
         IncidentCreateCmd,
@@ -305,7 +324,9 @@ Command = Annotated[
         IncidentsResetCmd,
         MeasureCreateCmd,
         MeasureRemoveCmd,
-        MeasuresClearCmd
+        MeasuresClearCmd,
+        PolicyActivateCmd,
+        PolicyDeactivateCmd
     ],
     Field(discriminator="command")]
 # < Command Wrappers ------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,3 +155,39 @@ class TestApi(unittest.TestCase):
         self.assertEqual(cmd.get("command"), CommandType.INCIDENTS_RESET)
         self.assertEqual(cmd.get("time"), time)
         self.assertEqual(cmd.get("payload"), None)
+
+    def test_policy_activate_endpoint(self):
+        """POST /policy/{id}?time={value} should enqueue the activate `id` policy at time of `value`"""
+        policy_id = 123456
+        time = 600
+        resp = self.client.post(f"/policy/{policy_id}?time={time}")
+        self.assertEqual(resp.status_code, HTTPStatus.ACCEPTED)
+        self.assertEqual(resp.json(), self.ACCEPTED_MSG)
+
+        msgs = self._drain_queue()
+        self.assertEqual(len(msgs), 1)
+
+        cmd = msgs[0]
+        self.assertEqual(cmd.get("command"), CommandType.POLICY_ACTIVATE)
+        self.assertEqual(cmd.get("time"), time)
+
+        payload = cmd["payload"]
+        self.assertEqual(payload["policy_id"], policy_id)
+
+    def test_policy_deactivate_endpoint(self):
+        """DELETE /policy/{id}?time={value} should enqueue the deactivate `id` policy at time of `value`"""
+        policy_id = 123456
+        time = 600
+        resp = self.client.delete(f"/policy/{policy_id}?time={time}")
+        self.assertEqual(resp.status_code, HTTPStatus.ACCEPTED)
+        self.assertEqual(resp.json(), self.ACCEPTED_MSG)
+
+        msgs = self._drain_queue()
+        self.assertEqual(len(msgs), 1)
+
+        cmd = msgs[0]
+        self.assertEqual(cmd.get("command"), CommandType.POLICY_DEACTIVATE)
+        self.assertEqual(cmd.get("time"), time)
+
+        payload = cmd["payload"]
+        self.assertEqual(payload["policy_id"], policy_id)


### PR DESCRIPTION
This pull request introduces a new feature for managing policies in the system, including activating and deactivating policies via API endpoints. It also includes updates to the command handling, data models, and tests to support the new functionality.

### New Policy Management Feature:

* Added new command types `POLICY_ACTIVATE` and `POLICY_DEACTIVATE` to the `CommandType` enum in `common/models.py` to represent policy actions.
* Introduced a new `PolicyTargetDto` model in `common/models.py` to represent the payload for policy-related commands.
* Added `PolicyActivateCmd` and `PolicyDeactivateCmd` classes in `common/models.py` to define the structure of policy commands.

### API Enhancements:

* Updated `server/api.py` to include new endpoints for activating (`POST /policy/{id}`) and deactivating (`DELETE /policy/{id}`) policies. These endpoints enqueue the respective commands with the provided policy ID and optional execution time. [[1]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adR84) [[2]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adR166-R182)
* Registered the new policy routes in the FastAPI application.

### Command Handling Updates:

* Added handlers for `POLICY_ACTIVATE` and `POLICY_DEACTIVATE` commands in `aimsun_entrypoint.py`. These handlers interact with the underlying API to activate or deactivate policies and return appropriate results.

### Test Coverage:

* Added unit tests in `tests/test_api.py` to verify the behavior of the new policy endpoints, ensuring that commands are correctly enqueued with the expected payloads and execution times.

### Other Changes:

* Updated imports in various files (`aimsun_entrypoint.py`, `server/api.py`) to include the new policy-related classes and models. [[1]](diffhunk://#diff-adf26732ab16791051c5d0c1a92bdf5b9355ef759cf7e42c3c2f298b2f71557cL100-R103) [[2]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adL26-R29)