### PR TITLE
feat: implement force turn commands

### DIFF
--- a/aimsun_entrypoint.py
+++ b/aimsun_entrypoint.py
@@ -452,7 +452,7 @@ def _(m: MeasureTurnForceResult) -> Result[int]:
 
 
 # > Policy dispatch ------------------------------------------------------------
-@ register_handler(CommandType.POLICY_ACTIVATE)
+@register_handler(CommandType.POLICY_ACTIVATE)
 def _policy_activate(payload: PolicyTargetDto):
     try:
         ANGConnActivatePolicy(payload.policy_id)
@@ -463,7 +463,7 @@ def _policy_activate(payload: PolicyTargetDto):
     return Result.ok(payload.policy_id, msg)
 
 
-@ register_handler(CommandType.POLICY_DEACTIVATE)
+@register_handler(CommandType.POLICY_DEACTIVATE)
 def _policy_deactivate(payload: PolicyTargetDto):
     try:
         ANGConnDeactivatePolicy(payload.policy_id)

--- a/common/models.py
+++ b/common/models.py
@@ -263,7 +263,7 @@ MeasurePayload = Annotated[
 
 
 class MeasureCreateDto(RootModel[MeasurePayload]):
-    @ property
+    @property
     def measure(self) -> MeasurePayload:
         return self.root
 
@@ -298,7 +298,7 @@ class IncidentCreateCmd(CommandBase):
     command: Literal[CommandType.INCIDENT_CREATE] = CommandType.INCIDENT_CREATE
     payload: IncidentCreateDto
 
-    @ model_validator(mode="after")
+    @model_validator(mode="after")
     def _ini_after_time(self):
         if self.payload.ini_time <= self.time:
             raise PydanticCustomError(

--- a/common/models.py
+++ b/common/models.py
@@ -42,7 +42,8 @@ class MeasureType(str, Enum):
     LANE_CLOSURE_DETAILED = "lane_closure_detailed"
     LANE_DEACTIVATE_RESERVED = "lane_deactivate_reserved"
     TURN_CLOSE = "turn_close"
-    TURN_FORCE = "turn_force"
+    TURN_FORCE_OD = "turn_force_od"
+    TURN_FORCE_RESULT = "turn_force_result"
 
 # < Enums ----------------------------------------------------------
 
@@ -208,8 +209,43 @@ class MeasureTurnClose(_MeasureBase):
                                                 description="Identifier to the section meant to affect the path calculation cost when the path comes from it")
 
 
-class MeasureTurnForce(_MeasureBase):
-    type: Literal[MeasureType.TURN_FORCE] = MeasureType.TURN_FORCE
+class _MeasureTurnForceBase(_MeasureBase):
+    """
+        Force the next turning movement of the vehicle on a section.
+        We use the same DTO to represent both measures for OD matrices and
+        traffic state objects.
+    """
+    from_section_id: int = Field(...,
+                                 description="Section where the forced turn begins")
+    next_section_ids: list[int] = Field(...,
+                                        min_length=1,
+                                        description="One or more candidate sections vehicles should take instead.")
+    veh_type: int = Field(default=0,
+                          ge=0,
+                          description="0 = all vehicles, 1..N specific vehicle types")
+    compliance: float = Field(default=1.0,
+                              ge=0.0,
+                              le=1.0,
+                              description="Share of drivers obeying the measure <0-1>")
+
+
+class MeasureTurnForceOD(_MeasureTurnForceBase):
+    """ Force turn action evaluated against OD paths. """
+    type: Literal[MeasureType.TURN_FORCE_OD] = MeasureType.TURN_FORCE_OD
+    origin_centroid:  int = Field(default=-1,
+                                  description="Centroid origin identifier, -1 means do not consider origin with set compliance")
+    destination_centroid:  int = Field(default=-1,
+                                       description="Centroid destination identifier, -1 means do not consider destination with set compliance")
+    section_in_path: int = Field(default=-1,
+                                 description="Restrict action to vehicles whose planned path already contains this section. -1 = ignore")
+    visibility_distance: float = Field(default=200,
+                                       description="Visibility distance in meters of the incident to be used in Aimsun 7.0 models.")
+
+
+class MeasureTurnForceResult(_MeasureTurnForceBase):
+    type: Literal[MeasureType.TURN_FORCE_RESULT] = MeasureType.TURN_FORCE_RESULT
+    old_next_section_id: int = Field(...,
+                                     description="Which outgoing section of the node to affect")
 
 
 MeasurePayload = Annotated[
@@ -220,13 +256,14 @@ MeasurePayload = Annotated[
         MeasureLaneClosureDetailed,
         MeasureLaneDeactivateReserved,
         MeasureTurnClose,
-        MeasureTurnForce
+        MeasureTurnForceOD,
+        MeasureTurnForceResult
     ],
     Field(discriminator="type")]
 
 
 class MeasureCreateDto(RootModel[MeasurePayload]):
-    @property
+    @ property
     def measure(self) -> MeasurePayload:
         return self.root
 
@@ -261,7 +298,7 @@ class IncidentCreateCmd(CommandBase):
     command: Literal[CommandType.INCIDENT_CREATE] = CommandType.INCIDENT_CREATE
     payload: IncidentCreateDto
 
-    @model_validator(mode="after")
+    @ model_validator(mode="after")
     def _ini_after_time(self):
         if self.payload.ini_time <= self.time:
             raise PydanticCustomError(

--- a/server/api.py
+++ b/server/api.py
@@ -22,6 +22,8 @@ from common.models import (
     MeasureLaneClosureDetailed,
     MeasureLaneDeactivateReserved,
     MeasureTurnClose,
+    MeasureTurnForceOD,
+    MeasureTurnForceResult,
     MeasureRemoveDto,
     MeasureRemoveCmd,
     MeasuresClearCmd,
@@ -41,7 +43,9 @@ from server.models import (
     MeasureLaneClosureInput,
     MeasureLaneClosureDetailedInput,
     MeasureLaneDeactivateReservedInput,
-    MeasureTurnCloseInput)
+    MeasureTurnCloseInput,
+    MeasureTurnForceInputOd,
+    MeasureTurnForceInputResult)
 
 from pydantic import BaseModel, Field
 from common.logger import get_logger
@@ -158,28 +162,42 @@ def register_measures(app: FastAPI, queue: mp.Queue) -> None:
         return _enqueue(queue,
                         _as_measure_create_cmd(data, MeasureTurnClose))
 
-    @app.delete("/measure/{measure_id}", status_code=HTTPStatus.ACCEPTED)
+    @app.post("/measure/turn-force/od", status_code=HTTPStatus.ACCEPTED)
+    def _measure_turn_force_od(data: MeasureTurnForceInputOd):
+        if log.isEnabledFor(DEBUG):
+            log.debug(json.dumps(data.model_dump(), indent=2))
+        return _enqueue(queue,
+                        _as_measure_create_cmd(data, MeasureTurnForceOD))
+
+    @app.post("/measure/turn-force/result", status_code=HTTPStatus.ACCEPTED)
+    def _measure_turn_force_od(data: MeasureTurnForceInputResult):
+        if log.isEnabledFor(DEBUG):
+            log.debug(json.dumps(data.model_dump(), indent=2))
+        return _enqueue(queue,
+                        _as_measure_create_cmd(data, MeasureTurnForceResult))
+
+    @ app.delete("/measure/{measure_id}", status_code=HTTPStatus.ACCEPTED)
     def _measure_remove(measure_id: int = Path(..., gt=0),
                         time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = MeasureRemoveCmd(time=time,
                                payload=MeasureRemoveDto(id_action=measure_id))
         return _enqueue(queue, cmd)
 
-    @app.post("/measures/reset", status_code=HTTPStatus.ACCEPTED)
+    @ app.post("/measures/reset", status_code=HTTPStatus.ACCEPTED)
     def _measures_clear(time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = MeasuresClearCmd(time=time)
         return _enqueue(queue, cmd)
 
 
 def register_policies(app: FastAPI, queue: mp.Queue) -> None:
-    @app.post("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
+    @ app.post("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
     def _policy_activate(policy_id: int = Path(..., gt=0),
                          time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = PolicyActivateCmd(time=time,
                                 payload=PolicyTargetDto(policy_id=policy_id))
         return _enqueue(queue, cmd)
 
-    @app.delete("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
+    @ app.delete("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
     def _policy_deactivate(policy_id: int = Path(..., gt=0),
                            time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = PolicyDeactivateCmd(time=time,

--- a/server/api.py
+++ b/server/api.py
@@ -176,28 +176,28 @@ def register_measures(app: FastAPI, queue: mp.Queue) -> None:
         return _enqueue(queue,
                         _as_measure_create_cmd(data, MeasureTurnForceResult))
 
-    @ app.delete("/measure/{measure_id}", status_code=HTTPStatus.ACCEPTED)
+    @app.delete("/measure/{measure_id}", status_code=HTTPStatus.ACCEPTED)
     def _measure_remove(measure_id: int = Path(..., gt=0),
                         time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = MeasureRemoveCmd(time=time,
                                payload=MeasureRemoveDto(id_action=measure_id))
         return _enqueue(queue, cmd)
 
-    @ app.post("/measures/reset", status_code=HTTPStatus.ACCEPTED)
+    @app.post("/measures/reset", status_code=HTTPStatus.ACCEPTED)
     def _measures_clear(time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = MeasuresClearCmd(time=time)
         return _enqueue(queue, cmd)
 
 
 def register_policies(app: FastAPI, queue: mp.Queue) -> None:
-    @ app.post("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
+    @app.post("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
     def _policy_activate(policy_id: int = Path(..., gt=0),
                          time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = PolicyActivateCmd(time=time,
                                 payload=PolicyTargetDto(policy_id=policy_id))
         return _enqueue(queue, cmd)
 
-    @ app.delete("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
+    @app.delete("/policy/{policy_id}", status_code=HTTPStatus.ACCEPTED)
     def _policy_deactivate(policy_id: int = Path(..., gt=0),
                            time: float = Query(default=CommandBase.IMMEDIATE)):
         cmd = PolicyDeactivateCmd(time=time,

--- a/server/models.py
+++ b/server/models.py
@@ -159,3 +159,34 @@ class MeasureTurnCloseInput(_MeasureBaseInput):
                                description="If vehicles do not have apriori knowledge of closure - true, else global knowledge")
     section_affecting_path_cost_id: int = Field(default=-1,
                                                 description="Identifier to the section meant to affect the path calculation cost when the path comes from it")
+
+
+class _MeasureTurnForceBaseInput(_MeasureBaseInput):
+    """ Body shared by both /measure/turn-force/* endpoints"""
+    from_section_id: int = Field(..., description="Section where action starts.")
+    next_section_ids: list[int] = Field(...,
+                                        min_length=1,
+                                        description="Destination section(s) vehicles should take")
+    veh_type: int = Field(default=0,
+                          ge=0,
+                          description="0 = all vehicles, 1..N specific vehicle types")
+    compliance: float = Field(default=1.0,
+                              ge=0.0,
+                              le=1.0,
+                              description="Share of drivers obeying the measure <0-1>")
+
+
+class MeasureTurnForceInputOd(_MeasureTurnForceBaseInput):
+    origin_centroid:  int = Field(default=-1,
+                                  description="Centroid origin identifier, -1 means do not consider origin with set compliance")
+    destination_centroid:  int = Field(default=-1,
+                                       description="Centroid destination identifier, -1 means do not consider destination with set compliance")
+    section_in_path: int = Field(default=-1,
+                                 description="Restrict action to vehicles whose planned path already contains this section. -1 = ignore")
+    visibility_distance: float = Field(default=200,
+                                       description="Visibility distance in meters of the incident to be used in Aimsun 7.0 models.")
+
+
+class MeasureTurnForceInputResult(_MeasureTurnForceBaseInput):
+    old_next_section_id: int = Field(...,
+                                     description="Which outgoing section of the node to affect")


### PR DESCRIPTION
This pull request introduces two new "force turn" measure types for the traffic simulation API, splitting the previous generic "turn_force" into `turn_force_od` (for OD-path-based enforcement) and `turn_force_result` (for traffic state object enforcement). The changes include new models, API endpoints, backend dispatch logic, and comprehensive tests for these new measures.

The most important changes are:

**API and Endpoint Additions:**
* Added two new POST endpoints: `/measure/turn-force/od` and `/measure/turn-force/result`, each accepting a dedicated payload schema and enqueuing the correct measure command. [[1]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adR165-R178) [[2]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adL44-R48) [[3]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adR25-R26)

**Model and Type Changes:**
* Split the old `TURN_FORCE` measure into two new types in the `MeasureType` enum: `TURN_FORCE_OD` and `TURN_FORCE_RESULT`, and created corresponding model classes (`MeasureTurnForceOD`, `MeasureTurnForceResult`) with relevant fields. [[1]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208L45-R46) [[2]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208L211-R248) [[3]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208L223-R260)
* Added new input models (`MeasureTurnForceInputOd`, `MeasureTurnForceInputResult`) for API validation, sharing a common base for required fields.

**Backend Dispatch Logic:**
* Registered new dispatch handlers for `MeasureTurnForceOD` and `MeasureTurnForceResult` in the backend, implementing the logic to call the correct simulation API functions and handle errors. [[1]](diffhunk://#diff-adf26732ab16791051c5d0c1a92bdf5b9355ef759cf7e42c3c2f298b2f71557cR403-R450) [[2]](diffhunk://#diff-adf26732ab16791051c5d0c1a92bdf5b9355ef759cf7e42c3c2f298b2f71557cR99-R100) [[3]](diffhunk://#diff-adf26732ab16791051c5d0c1a92bdf5b9355ef759cf7e42c3c2f298b2f71557cR129-R130)

**Testing Improvements:**
* Added comprehensive tests for both new endpoints, covering valid and invalid payloads, to ensure proper command queuing and input validation. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R161-R228) [[2]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R244-R248)

These changes collectively enhance the flexibility and specificity of forced turn measures in the simulation API, while ensuring robust validation and backend support.