### PR TITLE
feat: allow defining schedules in external files along inline definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _archive/
 AAPI.py
 __pycache__/
 *.log
+
+schedules/*

--- a/common/config.py
+++ b/common/config.py
@@ -1,15 +1,11 @@
 """
     Configuration loading utilities.
 
-    Configuration can be provided via a JSON or YAML file
-    whose location defaults to ``config.json`` in the project root.
+    Configuration can be provided via a JSON file ```config.json``` located in the project root
 
-    The configuration file may specify API parameters, logging levels and a list of
-    scheduled events that are applied when the simulation is ready.
-
-    The ``ScheduledCommand`` structure represents a scheduled command and
-    corresponds roughly to a message that would otherwise be sent via the REST
-    API.
+    The configuration file may specify API parameters, logging levels and a [list of]
+    schedule file[s] which can contain scheduled commands, the schedule can be placed in the
+    configuration file itself as well via the "schedule" key
 
     Each event has a ``command`` (matching the ``CommandType``), a
     ``time`` indicating when it should be executed (simulation seconds from
@@ -22,24 +18,26 @@
     The ``AppConfig`` structure represents the entire application configuration,
     ``api_host`` and ``api_port`` server to configure the REST API.
 
-    The ``schedule`` list contains ``ScheduledCommand`` instances and is used to schedule
+    The ``schedule`` list contains ``Command`` instances and is used to schedule
     commands when the simulation starts
 
-    The configuration file is optional, if it's missing or invalid, defaults will be supplied and
-    no additional events will be scheduled.
+    The configuration file and the schedule files are optional, if it's missing or invalid, defaults will be supplied and
+    no additional command will be scheduled.
 """
 
 from __future__ import annotations
 
 import json
+import yaml
 import pathlib
 from dataclasses import dataclass, field
-from typing import Any, Dict, Final, ClassVar
+from typing import Any, Dict, Final, ClassVar, List
 from pydantic import ValidationError
 
 from common.models import ScheduleRoot
 from common.logger import get_log_manager, get_logger
 from common.schedule import Schedule
+from common.constants import get_project_root
 
 
 log = get_logger(__name__)
@@ -76,6 +74,55 @@ class AppConfig:
     api_port: int = DEFAULT_PORT
     schedule: Schedule = field(default_factory=Schedule)
 
+    @staticmethod
+    def _iter_schedule_chunks(cfg: Dict[str, Any]) -> List[Any]:
+        """Yield schedule chunks (lists) in the order they are defined in the config mapping"""
+        for key, value in cfg.items():
+            if key == "schedule":
+                if value:
+                    yield value
+            elif key in {"schedule_file", "schedule_files"}:
+                files = value if isinstance(value, list) else [value]
+                for file in files:
+                    if not file:
+                        continue
+                    yield ("@file", file)
+
+    @classmethod
+    def _parse_schedule(cls,
+                        cfg: Dict[str, Any],
+                        cfg_dir: pathlib.Path) -> Schedule:
+        errors: list[str] = []
+        schedule: Schedule = Schedule()
+
+        def _try_insert(raw, label: str):
+            nonlocal schedule
+            nonlocal errors
+            try:
+                validated = ScheduleRoot.model_validate(raw).root
+                schedule.extend(validated)
+            except ValidationError as exc:
+                for err in exc.errors():
+                    loc = ".".join(map(str, err["loc"]))
+                    msg = f"{label}:{loc} -> {err['msg']} (input={err.get('input')!r})"
+                    errors.append(msg)
+                return
+
+        for chunk in cls._iter_schedule_chunks(cfg):
+            if isinstance(chunk, tuple) and chunk[0] == "@file":
+                path = pathlib.Path(chunk[1])
+                if not path.is_absolute():
+                    path = cfg_dir / path
+                log.info("Loading schedule file: %s", path)
+                _try_insert(_load_by_extension(path), str(path))
+            else:
+                _try_insert(chunk, "inline.schedule")
+
+        if errors:
+            log.error("Schedule contains errors:\n" + "\n".join(errors))
+
+        return schedule
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AppConfig:
         if not data:
@@ -96,18 +143,10 @@ class AppConfig:
                 logfile=settings.get("logfile"),
                 ansi=settings.get("ansi"))
 
-        log.debug("Reading schedule...")
-        raw_schedule = data.get("schedule", [])
-        try:
-            parsed = ScheduleRoot.model_validate(raw_schedule)
-            schedule = Schedule(parsed.root)
-            log.info("Loaded schedule, %d entries", len(schedule))
-        except ValidationError as exc:
-            for err in exc.errors():
-                loc = ".".join(str(p) for p in err["loc"])
-                log.error("Config error at %s → %s (input=%r)",
-                          loc, err["msg"], err.get("input"))
-            raise
+        log.debug("Processing schedule...")
+        schedule = cls._parse_schedule(data,
+                                       get_project_root())
+        log.info("Loaded schedule, %d entries", len(schedule))
         return AppConfig(api_host=api_host,
                          api_port=api_port,
                          schedule=schedule)
@@ -123,7 +162,33 @@ def _load_json(path: pathlib.Path) -> Dict[str, Any]:
         return {}
 
 
-def load_config(path: pathlib.Path = pathlib.Path(__file__).resolve().parent.parent / "config.json") -> AppConfig:
+def _load_yaml(path: pathlib.Path) -> Dict[str, Any]:
+    """Load YAML file from disk"""
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except Exception as exc:
+        log.exception("Failed to read config file '%s': %s", path, exc)
+        return {}
+
+
+def _load_by_extension(path: pathlib.Path) -> Dict[str, Any]:
+    try:
+        if path.suffix.lower() in {".yml", ".yaml"}:
+            return _load_yaml(path)
+        return _load_json(path)
+    except Exception as exc:
+        log.exception("Failed to read '%s': %s", path, exc)
+        return {}
+
+
+def load_config(path: pathlib.Path | None = None) -> AppConfig:
+    """
+    Load main configuration; if *path* is None, default to
+    <PROJECT_ROOT>/config.json.
+    """
+    if path is None:
+        path = get_project_root() / "config.json"
     log.info("Reading config from path: '%s'", path)
-    data = _load_json(path)
+    data = _load_by_extension(path)
     return AppConfig.from_dict(data)

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -19,6 +19,10 @@ class Schedule:
         for sc in items:
             self.push(sc)
 
+    def extend(self, items: Iterable[CommandBase]) -> None:
+        for cb in items:
+            self.push(cb)
+
     def push(self, cb: CommandBase) -> None:
         heapq.heappush(self._heap,
                        (cb.time, next(self._order), cb))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,7 +114,7 @@ class TestConfigParsing(unittest.TestCase):
 
     def test_invalid_schedule_raises(self):
         """Schedules containing invalid entries should raise a ValidationError."""
-        cfg_dict = {
+        bad_cfg = {
             "schedule": [
                 {
                     "command": "incident_create",
@@ -122,8 +122,11 @@ class TestConfigParsing(unittest.TestCase):
                 }
             ]
         }
-        with self.assertRaises(ValidationError):
-            AppConfig.from_dict(cfg_dict)
+        with self.assertLogs("common.config", level="ERROR") as cm:
+            cfg = AppConfig.from_dict(bad_cfg)
+
+        self.assertTrue(any("schedule contains errors" in msg.lower() for msg in cm.output))
+        self.assertEqual(len(cfg.schedule), 0)
 
     def test_implicit_time_is_set(self):
         """Entries without time field should have it set to `CommandBase.IMMEDIATE` implicitly"""


### PR DESCRIPTION
This pull request updates the configuration loading system to support multiple schedule sources, including external YAML/JSON schedule files and inline schedules, and improves error handling and flexibility. The changes primarily affect how schedules are loaded, validated, and reported, and add support for YAML configuration files.

**Key improvements:**

### Configuration and Schedule Loading

* Enhanced the configuration system to allow schedules to be specified either inline (via the `schedule` key) or through one or more external files (`schedule_file` or `schedule_files`), supporting both JSON and YAML formats. The loader now processes these sources in the order they appear in the config. [[1]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bL4-R8) [[2]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bR77-R125) [[3]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bL126-R193)
* Added support for loading the main configuration file as YAML, in addition to JSON, and made the configuration file path optional (defaults to `<PROJECT_ROOT>/config.json`).

### Schedule Parsing and Error Handling

* Improved schedule parsing to aggregate and log all validation errors found in any schedule source, rather than raising exceptions, and ensures that if errors are present, no invalid commands are scheduled. [[1]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bR77-R125) [[2]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bL99-L110)
* Updated the `Schedule` class to add an `extend` method, enabling efficient addition of multiple commands at once.

### Testing

* Updated tests to check that invalid schedules log errors and result in an empty schedule, rather than raising exceptions, aligning with the new error handling approach.