### PR TITLE
feat: allow specifying python executable or search for it in path

### DIFF
--- a/aimsun_entrypoint.py
+++ b/aimsun_entrypoint.py
@@ -578,7 +578,9 @@ def _load():
     # hash / mtime on config -> cache it?
     _CONFIG = load_config()
     log = get_logger("aimsun.entrypoint")
-    _SERVER = ServerProcess(host=_CONFIG.api_host, port=_CONFIG.api_port)
+    _SERVER = ServerProcess(host=_CONFIG.api_host,
+                            port=_CONFIG.api_port,
+                            executable=_CONFIG.python_location)
     _SCHEDULE = _CONFIG.schedule
     _ID_GEN = count(1)
 

--- a/common/config.py
+++ b/common/config.py
@@ -60,6 +60,10 @@ class AppConfig:
     api_port:
         Optional override for the API port. If ``None`` the default
         ``ServerProcess`` port is used.
+    python_location:
+        If specified, use this executable to launch the server process,
+        otherwise we attempt to lookup the correct version in users PATH.
+        specified with the key python_executable.
     schedule:
         Sequence of scheduled command that should be executed when the
         simulation runs either at a particular time or immediately.
@@ -72,6 +76,7 @@ class AppConfig:
     DEFAULT_PORT: ClassVar[Final[int]] = 6969
     api_host: str = DEFAULT_HOST
     api_port: int = DEFAULT_PORT
+    python_location: str | None = None
     schedule: Schedule = field(default_factory=Schedule)
 
     @staticmethod
@@ -132,6 +137,8 @@ class AppConfig:
         api_host = api_cfg.get("host") or AppConfig.DEFAULT_HOST
         api_port = api_cfg.get("port") or AppConfig.DEFAULT_PORT
 
+        py_location = data.get("python_location")
+
         log_manager = get_log_manager()
         log_cfg = data.get("log", {})
         log_manager.default_level = log_manager.parse_level(log_cfg.get("level", "INFO"))
@@ -149,6 +156,7 @@ class AppConfig:
         log.info("Loaded schedule, %d entries", len(schedule))
         return AppConfig(api_host=api_host,
                          api_port=api_port,
+                         python_location=py_location,
                          schedule=schedule)
 
 


### PR DESCRIPTION
This pull request introduces support for specifying a custom Python executable location for the server process, improving flexibility and reliability when launching the server. The main changes involve updating the configuration system to accept a `python_location` parameter and enhancing the logic for resolving the correct Python interpreter.

**Configuration enhancements:**

* Added a new `python_location` field to the `AppConfig` class, allowing users to specify the Python executable to use for the server process. This is now parsed from the configuration dictionary and passed through the application. [[1]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bR63-R66) [[2]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bR79) [[3]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bR140-R141) [[4]](diffhunk://#diff-1bacff878451e5aa9c6d164150c7b2daad028d5e7acba90bb720cb73ffdd827bR159)

**Server process improvements:**

* Updated the `ServerProcess` class to accept an optional `executable` parameter, which is used as the Python interpreter if provided. The process for resolving the Python executable now prioritizes the configured value and includes more robust logic for locating a suitable Python 3.10 interpreter, raising an error if none is found. [[1]](diffhunk://#diff-a3f6d342575711531bc0700fb76bb3776281b32c5f3a1bdd3a0d836e7ccded43R7-R28) [[2]](diffhunk://#diff-a3f6d342575711531bc0700fb76bb3776281b32c5f3a1bdd3a0d836e7ccded43L63-R105) [[3]](diffhunk://#diff-adf26732ab16791051c5d0c1a92bdf5b9355ef759cf7e42c3c2f298b2f71557cL581-R583)