### PR TITLE
fix: add missing import

### DIFF
--- a/aimsun_entrypoint.py
+++ b/aimsun_entrypoint.py
@@ -108,6 +108,7 @@ def _imports():
     _import_one("common.result", from_list=["Result"])
     _import_one("server.ipc", from_list=["ServerProcess"])
     _import_one("common.schedule", from_list=["Schedule"])
+    _import_one("common.status", from_list=["AimsunStatus"])
 
 
 if TYPE_CHECKING:

--- a/config.json
+++ b/config.json
@@ -29,27 +29,5 @@
       }
     }
   },
-  "schedule": [
-    {
-      "command": "measure_create",
-      "time": 60,
-      "payload": {
-        "type": "destination_change",
-        "duration": 600,
-        "section_id": 492,
-        "destination_centroid": 502,
-        "origin_centroid": 500,
-        "new_destinations": [
-          { 
-            "dest_id": 501,
-            "percentage": 80.0
-          },
-          { 
-            "dest_id": 502,
-            "percentage": 20.0
-          }
-        ]
-      }
-    }
-  ]
+  "schedule_file": "schedules/destination-change.yml",
 }


### PR DESCRIPTION
This pull request updates how schedules are managed and adds a missing import. The main change is to shift schedule configuration from being directly embedded in `config.json` to referencing an external YAML file, which should help with organization and maintainability. Additionally, a new import is added to support status tracking.

Configuration changes:

* Replaced the inline `schedule` array in `config.json` with a `schedule_file` key pointing to `schedules/destination-change.yml`, moving schedule details to an external YAML file for better separation of configuration.

Codebase maintenance:

* Added import of `AimsunStatus` from `common.status` in the `_imports` function in `aimsun_entrypoint.py` to ensure all necessary status-related functionality is available.