### PR TITLE
refactor: cleanup, use | None instead of Optional

### DIFF
--- a/common/logger.py
+++ b/common/logger.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import pathlib
 from logging.handlers import RotatingFileHandler
-from typing import Final, Optional, TextIO
+from typing import Final, TextIO
 from common.constants import get_project_root
 
 LEVEL_COLOURS: Final[dict[int, str]] = {
@@ -27,7 +27,7 @@ class LogLevelFormatter(logging.Formatter):
 class LogManager:
     def __init__(self,
                  default_level: str = "INFO",
-                 default_logfile: Optional[pathlib.Path] = None,
+                 default_logfile: pathlib.Path | None = None,
                  use_colors: bool = False):
         self.default_level = self.parse_level(default_level)
         self.default_logfile = default_logfile
@@ -37,9 +37,9 @@ class LogManager:
 
     def configure_component(self,
                             name: str,
-                            level: Optional[str] = None,
-                            logfile: Optional[str] = None,
-                            ansi: Optional[bool] = None) -> None:
+                            level: str | None = None,
+                            logfile: str | None = None,
+                            ansi: bool | None = None) -> None:
         """Override log settings for a specific component/module."""
         if logfile:
             log_path: pathlib.Path = pathlib.Path(logfile)
@@ -107,7 +107,7 @@ class LogManager:
                 print(f"        ansi   : {conf['ansi']}", file=stream)
 
     @staticmethod
-    def parse_level(level: Optional[str]) -> int:
+    def parse_level(level: str | None) -> int:
         if not level:
             return logging.INFO
         return getattr(logging, level.upper(), logging.INFO)

--- a/common/result.py
+++ b/common/result.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TypeVar, Generic, Optional
+from typing import TypeVar, Generic
 from common.status import AimsunStatus
 
 T = TypeVar("T")
@@ -9,9 +9,9 @@ class Result(Generic[T]):
     def __init__(
         self,
         status: AimsunStatus,
-        value: Optional[T] = None,
-        raw_code: Optional[int] = None,
-        message: Optional[str] = None,
+        value: T | None = None,
+        raw_code: int | None = None,
+        message: str | None = None,
     ):
         self.status = status
         self.value = value
@@ -45,8 +45,8 @@ class Result(Generic[T]):
     @classmethod
     def from_aimsun(cls,
                     result: int, *,
-                    msg_ok: Optional[str] = None,
-                    msg_err: Optional[str] = None) -> Result[int]:
+                    msg_ok: str | None = None,
+                    msg_err: str | None = None) -> Result[int]:
         success = result >= 0
         status = AimsunStatus.OK if success else AimsunStatus.from_code(result)
         message = (msg_ok if success else msg_err)

--- a/server/api.py
+++ b/server/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import multiprocessing as mp
-from fastapi import FastAPI, Header, Path, Query
-from typing import Any, Generic, TypeVar, Optional
+from fastapi import FastAPI,  Path, Query
+from typing import Any
 from logging import DEBUG
 
 import json
@@ -41,7 +41,6 @@ from server.models import (
     ScheduledBase,
     IncidentCreateInput,
     IncidentRemoveInput,
-    IncidentsClearSectionInput,
     _MeasureBaseInput,
     MeasureSpeedSectionInput,
     MeasureSpeedDetailedInput,
@@ -53,7 +52,6 @@ from server.models import (
     MeasureTurnForceInputResult,
     MeasureDestinationChangeInput)
 
-from pydantic import BaseModel, Field
 from common.logger import get_logger
 from http import HTTPStatus
 

--- a/server/models.py
+++ b/server/models.py
@@ -21,7 +21,6 @@ we flatten it into:
     "parameter_n": xxx
 }
 """
-from typing import Optional
 from pydantic import BaseModel, Field, model_validator
 
 from common.models import (
@@ -36,7 +35,7 @@ from common.models import (
 
 
 class ScheduledBase(BaseModel):
-    time: Optional[float] = Field(default=CommandBase.IMMEDIATE)
+    time: float | None = Field(default=CommandBase.IMMEDIATE)
 
 
 class IncidentCreateInput(IncidentCreateDto, ScheduledBase):


### PR DESCRIPTION
This pull request focuses on modernizing type annotations across several modules by replacing usage of `Optional` from the `typing` module with the more concise `| None` syntax introduced in Python 3.10. It also removes unused imports related to `Optional`. These changes simplify the codebase and make type annotations clearer and more consistent.

**Type annotation modernization:**

* Replaced `Optional[...]` with `... | None` in function signatures and class attributes throughout `common/logger.py`, `common/result.py`, and `server/models.py` to use the modern Python type annotation style. [[1]](diffhunk://#diff-6c58b7a14a8a445dcfecff70d939dae0c3b444fb2701354eb94ca2dd98a27d99L5-R5) [[2]](diffhunk://#diff-6c58b7a14a8a445dcfecff70d939dae0c3b444fb2701354eb94ca2dd98a27d99L30-R30) [[3]](diffhunk://#diff-6c58b7a14a8a445dcfecff70d939dae0c3b444fb2701354eb94ca2dd98a27d99L40-R42) [[4]](diffhunk://#diff-6c58b7a14a8a445dcfecff70d939dae0c3b444fb2701354eb94ca2dd98a27d99L110-R110) [[5]](diffhunk://#diff-1635665a555c907d1a0e3917c01e00c1528f9b20b63dd8caef7511353e1e5e8eL2-R2) [[6]](diffhunk://#diff-1635665a555c907d1a0e3917c01e00c1528f9b20b63dd8caef7511353e1e5e8eL12-R14) [[7]](diffhunk://#diff-1635665a555c907d1a0e3917c01e00c1528f9b20b63dd8caef7511353e1e5e8eL48-R49) [[8]](diffhunk://#diff-d97741605a183dfd2c9975818dd030d80edfef76b2dd3fa5f696604068146b8aL24) [[9]](diffhunk://#diff-d97741605a183dfd2c9975818dd030d80edfef76b2dd3fa5f696604068146b8aL39-R38)

**Code cleanup:**

* Removed unused or unnecessary imports of `Optional` and related imports from `typing` in `common/logger.py`, `common/result.py`, `server/api.py`, and `server/models.py`. [[1]](diffhunk://#diff-6c58b7a14a8a445dcfecff70d939dae0c3b444fb2701354eb94ca2dd98a27d99L5-R5) [[2]](diffhunk://#diff-1635665a555c907d1a0e3917c01e00c1528f9b20b63dd8caef7511353e1e5e8eL2-R2) [[3]](diffhunk://#diff-d8a9741c169ca9f7e5aa223ea65d0373a9862126a98ebb76dae6e51a631962adL3-R4) [[4]](diffhunk://#diff-d97741605a183dfd2c9975818dd030d80edfef76b2dd3fa5f696604068146b8aL24)
* Removed an unused import of `IncidentsClearSectionInput` from `server/api.py`.
* Removed an unused import of `BaseModel` and `Field` from `server/api.py`.