### PR TITLE
feat: allow specifying incident visibility distances per vehicle type

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,6 +93,31 @@ class TestApi(unittest.TestCase):
         resp_payload = cmd["payload"]
         self.assertEqual(payload | resp_payload, resp_payload)
 
+    def test_incident_create_endpoint_per_veh_valid(self):
+        """POST /incident with a valid payload with distances per vehicle returns 202 and enqueues a command"""
+        payload = {
+            "section_id": 1,
+            "lane": 1,
+            "position": 0.0,
+            "length": 5.0,
+            "ini_time": 5.0,
+            "duration": 60.0,
+            "visibility_distance": 200.0,
+            "per_veh_visibility": [
+                {"veh_type": 1, "distance": 150.0},
+                {"veh_type": 2, "distance": 250.0}
+            ],
+            "apply_speed_reduction": True,
+            "max_speed_SR": 30.0
+        }
+        resp = self.client.post("/incident", json=payload)
+        self.assertEqual(resp.status_code, HTTPStatus.ACCEPTED)
+        self.assertEqual(resp.json(), self.ACCEPTED_MSG)
+        cmd, = self._drain_queue()
+        self.assertEqual(cmd["command"], CommandType.INCIDENT_CREATE)
+        resp_payload = cmd["payload"]
+        self.assertEqual(payload | resp_payload, resp_payload)
+
     def test_incident_create_endpoint_invalid_payload(self):
         """POST /incident with missing fields should return a 422 Unprocessable Entity."""
         payload = {


### PR DESCRIPTION
This pull request adds support for specifying incident visibility distances per vehicle type, enhancing the flexibility of incident creation. It introduces new data structures, validation logic, and updates to the incident creation workflow to handle this feature. Additionally, new tests are included to ensure correct API behavior for the new functionality.

**Incident creation enhancements:**
- Added a new `VehicleVisibility` model and updated the `IncidentCreateDto` to include an optional `per_veh_visibility` field, allowing users to specify visibility distances for individual vehicle types. Also added a validator to prevent duplicate vehicle types in the list. [[1]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208R54-R60) [[2]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208L69-R80) [[3]](diffhunk://#diff-a9dbd33eecd80da366708c7eef0b5c971c7bbf89b5027a23e3382062f7632208R92-R101)
- Refactored the incident creation logic in `aimsun_entrypoint.py` to handle per-vehicle-type visibility: if `per_veh_visibility` is provided, the new `_incident_create_per_veh` function is used; otherwise, the existing logic is used. [[1]](diffhunk://#diff-adf26732ab16791051c5d0c1a92bdf5b9355ef759cf7e42c3c2f298b2f71557cL182-R216) [[2]](diffhunk://#diff-adf26732ab16791051c5d0c1a92bdf5b9355ef759cf7e42c3c2f298b2f71557cL197-R244)

**Testing improvements:**
- Added a new test case to verify that the API correctly handles incident creation requests with per-vehicle-type visibility distances.